### PR TITLE
fix: ctrl+c does not end the child process

### DIFF
--- a/lib/spawnify.js
+++ b/lib/spawnify.js
@@ -158,7 +158,15 @@ Spawnify.prototype._set = function set(type, command, options) {
         this._setListeners(child);
         
         this.on('kill', (code) => {
-            child.kill(code);
+            // Can only end the first process
+            // child.kill(code);
+
+            // Can end subprocess, but at the expense of `code`
+            import('fkill').then(fkill => fkill.default(child.pid, {
+                force: true,
+            })).catch(err => {
+                console.log(`Process has been terminated, or other errors.`)
+            });
         });
         
         this.on('write', (data) => {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": ">=14"
   },
   "dependencies": {
+    "fkill": "^8.0.1",
     "glob": "^7.1.0",
     "tildify": "^2.0.0",
     "try-catch": "^3.0.0",


### PR DESCRIPTION
See: https://github.com/coderaiser/cloudcmd/issues/190

``` js
this.on('kill', (code) => {
    // Can only end the first process
    // child.kill(code);

    // Can end subprocess, but at the expense of `code`
    import('fkill').then(fkill => fkill.default(child.pid, {
        force: true,
    })).catch(err => {
        console.log(`Process has been terminated, or other errors.`)
    });
});
```